### PR TITLE
Implement the monadic run functions

### DIFF
--- a/haskell-ricochet.cabal
+++ b/haskell-ricochet.cabal
@@ -49,6 +49,7 @@ library
                      , Network.Ricochet.Protocol.Data.Control.Packet
   -- other-extensions:    
   build-depends:       base
+                     , base32string
                      , network
                      , mtl
                      , lens
@@ -68,6 +69,7 @@ library
 executable server
   main-is:             src/Demo/Server.hs
   build-depends:       base
+                     , base32string
                      , mtl
                      , containers
                      , bytestring
@@ -79,6 +81,7 @@ executable server
 executable client
   main-is:             src/Demo/Client.hs
   build-depends:       base
+                     , base32string
                      , mtl
                      , containers
                      , bytestring

--- a/nix/network-anonymous-tor.nix
+++ b/nix/network-anonymous-tor.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, attoparsec, base, base32string, bytestring
+, exceptions, fetchgit, hexstring, hspec, hspec-attoparsec
+, hspec-expectations, network, network-attoparsec, network-simple
+, socks, splice, stdenv, text, transformers
+}:
+mkDerivation {
+  pname = "network-anonymous-tor";
+  version = "0.10.0";
+  src = fetchgit {
+    url = "https://github.com/solatis/haskell-network-anonymous-tor";
+    sha256 = "9adb606d73b04dfb261d6e899b7a25626c600f386cc9aa203a32633955a87807";
+    rev = "464e63373aea426a5efd11577311fe5177b8e78a";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    attoparsec base base32string bytestring exceptions hexstring
+    network network-attoparsec network-simple socks text transformers
+  ];
+  executableHaskellDepends = [
+    base exceptions network network-simple splice
+  ];
+  testHaskellDepends = [
+    attoparsec base base32string bytestring exceptions hspec
+    hspec-attoparsec hspec-expectations network network-simple socks
+    text transformers
+  ];
+  doCheck = false;
+  homepage = "http://www.leonmergen.com/opensource.html";
+  description = "Haskell API for Tor anonymous networking";
+  license = stdenv.lib.licenses.mit;
+}

--- a/src/Demo/Server.hs
+++ b/src/Demo/Server.hs
@@ -7,18 +7,21 @@ import           Network.Ricochet.Connection
 import           Network.Ricochet.Monad
 import           Network.Ricochet.Types
 
+import           Control.Concurrent          (threadDelay)
 import           Control.Lens
 import           Control.Monad.State
 import           Data.ByteString             (ByteString (), pack)
 import qualified Data.Map                    as M
 import           Data.Monoid                 ((<>))
-import           Network                     hiding (connectTo)
+import           Network                     hiding (accept, connectTo)
 
-main = do
-  state <- createState (PortNumber 9878)
-  flip (runStateT . runRicochet) state $ do
-    versions %= M.insert 1 (\_ -> return ())
-    con <- awaitConnection
-    forever $ do
-      p <- nextPacket con
-      liftIO $ print p
+main =
+  startRicochet (PortNumber 9878) Nothing (PortNumber 9051) [] (PortNumber 9050) [(1, handler)]
+    (\addr -> do
+      liftIO . print $ addr
+      void awaitConnection)
+
+handler con =
+  forever $ do
+    p <- nextPacket con
+    liftIO $ print p

--- a/src/Network/Ricochet.hs
+++ b/src/Network/Ricochet.hs
@@ -10,6 +10,54 @@ import Network.Ricochet.Types
 import Network.Ricochet.Util
 import Network.Ricochet.Version
 
-import Network (PortID(..))
-import Control.Monad.State (runStateT)
+import Data.Map (fromList)
+import Data.Base32String (Base32String)
+import Data.ByteString (ByteString)
+import Data.Word (Word8)
+import Network (PortID(..), Socket, listenOn)
 import Control.Lens
+import Control.Monad (void, forever)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.State (evalStateT)
+import Network.Anonymous.Tor (mapOnion, withSession)
+
+-- | Start an action inside the Ricochet monad.
+--
+--   This function uses a Tor control socket to create the hidden service.
+--   If no key is supplied, the hidden service will be random
+startRicochet :: PortID           -- ^ Port to listen on
+              -> Maybe ByteString -- ^ RSA1024 private key in base64 encoding
+              -> PortID           -- ^ The Tor control port
+              -> [Contact]        -- ^ A list of known 'Contact's
+              -> PortID           -- ^ The port of the Tor SOCKS5 proxy
+              -> [(Word8, Connection -> Ricochet ())] -- ^ A list of version identifiers and their
+                                                      --   corresponding 'Connection' handlers
+              -> (Base32String -> Ricochet ()) -- ^ The action will be supplied the address of the
+                                               --   hidden service
+              -> IO ()
+startRicochet lPort@(PortNumber listenPort) key (PortNumber ctrlPort) contacts socksPort versions action = do
+  let listenInt = fromIntegral listenPort
+      ctrlInt   = fromIntegral ctrlPort
+  listenSock <- listenOn lPort
+  void . withSession ctrlInt $ \ctrlSock -> do
+    address <- mapOnion ctrlSock listenInt listenInt False key
+    startRicochet' listenSock contacts socksPort versions . action $ address
+startRicochet _ _ _ _ _ _ _ = error "network-anonymous-tor currently only accepts Integers as ports, sorry"
+
+-- | Start an action inside the Ricochet monad.
+--
+--   This function assumes the listening socket was already configured to be a
+--   hidden service via the torrc or some other method.
+--
+--   DON'T use this function if that's not the case.
+startRicochet' :: Socket   -- ^ Socket to listen on
+              -> [Contact] -- ^ A list of known contacts
+              -> PortID    -- ^ The port of the Tor SOCKS5 proxy
+              -> [(Word8, Connection -> Ricochet ())] -- ^ A list of version identifiers and their
+                                                      --   corresponding 'Connection' handlers
+              -> Ricochet () -- ^ The action to execute
+              -> IO ()
+startRicochet' sock contacts soxPort versions action =
+  let versions' = fromList versions
+      state     = MkRicochetState sock [] contacts soxPort versions'
+  in flip evalStateT state . runRicochet $ action

--- a/src/Network/Ricochet.hs
+++ b/src/Network/Ricochet.hs
@@ -19,6 +19,7 @@ import Control.Lens
 import Control.Monad (void, forever)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (evalStateT)
+import Network.BSD (getServicePortNumber)
 import Network.Anonymous.Tor (mapOnion, withSession)
 
 -- | Start an action inside the Ricochet monad.
@@ -35,6 +36,14 @@ startRicochet :: PortID           -- ^ Port to listen on
               -> (Base32String -> Ricochet ()) -- ^ The action will be supplied the address of the
                                                --   hidden service
               -> IO ()
+-- Convert the lPort to a PortNumber, if it's a service
+startRicochet (Service s) key ctrlPort contacts socksPort versions action = do
+  portNum <- getServicePortNumber s
+  startRicochet (PortNumber portNum) key ctrlPort contacts socksPort versions action
+-- Convert the ctrlPort to a PortNumber, if it's a service
+startRicochet lPort key (Service s) contacts socksPort versions action = do
+  portNum <- getServicePortNumber s
+  startRicochet lPort key (PortNumber portNum) contacts socksPort versions action
 startRicochet lPort@(PortNumber listenPort) key (PortNumber ctrlPort) contacts socksPort versions action = do
   let listenInt = fromIntegral listenPort
       ctrlInt   = fromIntegral ctrlPort
@@ -42,7 +51,7 @@ startRicochet lPort@(PortNumber listenPort) key (PortNumber ctrlPort) contacts s
   void . withSession ctrlInt $ \ctrlSock -> do
     address <- mapOnion ctrlSock listenInt listenInt False key
     startRicochet' listenSock contacts socksPort versions . action $ address
-startRicochet _ _ _ _ _ _ _ = error "network-anonymous-tor currently only accepts Integers as ports, sorry"
+startRicochet _ _ _ _ _ _ _ = error "Unfortunately, startRicochet doesn't support UNIX sockets"
 
 -- | Start an action inside the Ricochet monad.
 --


### PR DESCRIPTION
As you can see, there's still the problem on how to handle the. I think there are two options here:
- Create a pull request changing the handling of ports in `network-anonymous-tor`
- Just use `Int`s or `Integer`s as ports, as `PortID` is annoying to use and you usually only end up using `PortNumber` anyways.

Another thing is, that `startRicochet` doesn't really need to be passed the SOCKS port, as it can query it over the control socket. Unfortunately, this doesn't seem to be working properly, so I'll be taking a look at that and change it as soon as it's fixed.
