### PR TITLE
Improve protobuf lenses

### DIFF
--- a/src/Network/Ricochet/Protocol/Protobuf.hs
+++ b/src/Network/Ricochet/Protocol/Protobuf.hs
@@ -11,6 +11,8 @@ module Network.Ricochet.Protocol.Protobuf
   ( ext
   , msg
   , utf8'
+  , i32
+  , d
   ) where
 
 import           Control.Lens             (Iso', Prism', Traversal', (^?), _1,
@@ -24,6 +26,8 @@ import           Text.ProtocolBuffers     (Default, ExtKey, Key,
                                            ReflectDescriptor, Utf8(..), Wire,
                                            defaultValue, utf8, getExt,
                                            messageGet, messagePut, putExt)
+import           GHC.Word                 (Word16)
+import           GHC.Int                  (Int32)
 
 -- | Take an extension key and return a Traversal' that yields all the values to
 --   that extension key
@@ -37,3 +41,11 @@ msg = lazy . prism' messagePut (^? to messageGet . _Right . _1)
 -- | A Prism that can encode and decode 'Utf8' from and to 'Text'.
 utf8' :: Prism' Utf8 Text
 utf8' = iso utf8 Utf8 . strict . prism' encodeUtf8 (^? to decodeUtf8' . _Right)
+
+-- | Isomorphism between Word16 and Int32
+i32 :: Iso' Word16 Int32
+i32 = iso fromIntegral fromIntegral
+
+-- | Shortcut for creating protobuf messages and filling them using lenses
+d :: Default a => a
+d = defaultValue

--- a/src/Network/Ricochet/Protocol/Protobuf/AuthHiddenService.hs
+++ b/src/Network/Ricochet/Protocol/Protobuf/AuthHiddenService.hs
@@ -11,6 +11,8 @@ prove ownership of a service name before sending a contact request.
 See <https://github.com/ricochet-im/ricochet/blob/master/doc/protocol.md#authhiddenservice ricochet’s protocol specification>.
 -}
 
+{-# LANGUAGE NoMonomorphismRestriction #-}
+
 module Network.Ricochet.Protocol.Protobuf.AuthHiddenService
   ( client_cookie
   , server_cookie
@@ -40,13 +42,11 @@ import           Data.ByteString                  (ByteString)
 
 -- | The client’s part of the random string that will be used as an input to
 --   calculate the proof.
-client_cookie :: Traversal' OpenChannel ByteString
-client_cookie = ext _client_cookie . _Just . strict
+client_cookie = ext _client_cookie
 
 -- | The server’s part of the random string that will be used as an input to
 --   calculate the proof.
-server_cookie :: Traversal' ChannelResult ByteString
-server_cookie = ext _server_cookie . _Just . strict
+server_cookie = ext _server_cookie
 
 -- | If the 'AP.Packet' came from the client, it /must/ contain a 'Proof'.  It
 --   is used to prove the ownership of a hidden service to the server.

--- a/src/Network/Ricochet/Protocol/Protobuf/ControlChannel.hs
+++ b/src/Network/Ricochet/Protocol/Protobuf/ControlChannel.hs
@@ -51,28 +51,28 @@ import           Text.ProtocolBuffers             (Seq)
 
 -- | A request to to open an additional channel.  The receiver should check its
 --   validity and reply with a 'R.ChannelResult' message.
-open_channel :: Traversal' CP.Packet O.OpenChannel
-open_channel = CP.open_channel . _Just
+open_channel :: Lens' CP.Packet (Maybe O.OpenChannel)
+open_channel = CP.open_channel
 
 -- | Response to an 'O.OpenChannel' message, telling the receiver whether the
 --   channel is ready for use, or what has gone wrong.
-channel_result :: Traversal' CP.Packet R.ChannelResult
-channel_result = CP.channel_result . _Just
+channel_result :: Lens' CP.Packet (Maybe R.ChannelResult)
+channel_result = CP.channel_result
 
 -- | A ping/pong message. This can be used to ping the remote side, ie. to find
 --   out how much latency the connection has.
-keep_alive :: Traversal' CP.Packet K.KeepAlive
-keep_alive = CP.keep_alive . _Just
+keep_alive :: Lens' CP.Packet (Maybe K.KeepAlive)
+keep_alive = CP.keep_alive
 
 -- | Request to activate protocol extension features.  The remote side has to
 --   respond with a 'F.FeaturesEnabled' message.
-enable_features :: Traversal' CP.Packet E.EnableFeatures
-enable_features = CP.enable_features . _Just
+enable_features :: Lens' CP.Packet (Maybe E.EnableFeatures)
+enable_features = CP.enable_features
 
 -- | Response to an 'E.EnableFeatures' message, telling the receiver which of
 --   the requested features have been enabled.
-features_enabled :: Traversal' CP.Packet F.FeaturesEnabled
-features_enabled = CP.features_enabled . _Just
+features_enabled :: Lens' CP.Packet (Maybe F.FeaturesEnabled)
+features_enabled = CP.features_enabled
 
 class HasChannelIdentifier m where
   -- | We use the typeclass 'HasChannelIdentifier' because both 'O.OpenChannel'
@@ -111,8 +111,8 @@ opened :: Lens' R.ChannelResult Bool
 opened = R.opened
 
 -- | The error code that describes why the channel cannot be opened.
-common_error :: Traversal' R.ChannelResult CE.CommonError
-common_error = R.common_error . _Just
+common_error :: Lens' R.ChannelResult (Maybe CE.CommonError)
+common_error = R.common_error
 
 -- | Whether this ping should be answered with a pong.  In other words, the
 --   remote side will reply to a 'K.KeepAlive' message with 'response_requested'

--- a/src/Network/Ricochet/Types.hs
+++ b/src/Network/Ricochet/Types.hs
@@ -10,12 +10,16 @@ lenses used throughout the package.
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Ricochet.Types where
 
-import           Control.Lens                    (makeLenses, makePrisms)
-import           Data.ByteString                 (ByteString ())
-import qualified Data.ByteString as B
-import           Data.Word                       (Word16)
-import           Network.Socket                  (Socket ())
-import           System.IO                       (Handle ())
+import           Control.Lens                     (makeLenses, makePrisms)
+import           Data.Map                         (Map ())
+import           Data.Text                        (Text)
+import           Control.Monad.IO.Class           (MonadIO (..))
+import           Control.Monad.State              (MonadState (..), StateT (..))
+import           Data.ByteString                  (ByteString ())
+import qualified Data.ByteString as B             (empty, length)
+import           Data.Word                        (Word16)
+import           Network.Socket                   (Socket ())
+import           System.IO                        (Handle ())
 
 -- | Low level representation of a ricochet packet
 data Packet = MkPacket
@@ -62,7 +66,7 @@ data Channel = MkChannel
   }
 
 -- | The type of a channel is preliminarily represented by a ByteString for extensibility
-data ChannelType = MkChannelType ByteString
+data ChannelType = MkChannelType Text
 
 -- | A contact, defined by his ID (TOR hidden service address without the .onion and the 'ricochet:' prefix) and his display name
 data Contact = MkContact


### PR DESCRIPTION
The lenses were broken just a bit, have a look at the commit message for more information on that.  In addition, I added `d` to the Protobuf utils module, which is quite useful:

``` haskell
let r :: Control.Packet = d & channel_result .~ Just
         (d & channel_identifier .~ 0
            & opened .~ True
            & common_error .~ Nothing)
```

I’m not sure about the name though...  It should be a lot shorter than `defaultValue`, since that’d just be annoying.
