### PR TITLE
Improve types

### DIFF
--- a/src/Demo/Client.hs
+++ b/src/Demo/Client.hs
@@ -5,6 +5,7 @@ module Main where
 import           Network.Ricochet
 import           Network.Ricochet.Connection
 import           Network.Ricochet.Monad
+import           Network.Ricochet.Types
 
 import           Control.Concurrent          (threadDelay)
 import           Control.Lens
@@ -18,12 +19,12 @@ import           System.Environment          (getArgs)
 main = do
   args <- getArgs
   when (length args /= 1) $ error "Usage: client <onion address>"
-  startRicochet (PortNumber 9879) Nothing (PortNumber 9051) [] (PortNumber 9050) [(1, handler)]
-    (\addr -> do
-      liftIO . print $ addr
-      con <- connectTo (head args) (PortNumber 9878)
-      liftIO . putStrLn $ "Connected!"
-      nextPacket con >>= liftIO . print)
+  startRicochet (PortNumber 9879) Nothing (PortNumber 9051) [] (PortNumber 9050) [(1, handler)] $ do
+    addr <- use hiddenDomain
+    liftIO . print $ addr
+    con <- connectTo (head args) (PortNumber 9878)
+    liftIO . putStrLn $ "Connected!"
+    nextPacket con >>= liftIO . print
 
 handler con =
   forever $ do

--- a/src/Demo/Server.hs
+++ b/src/Demo/Server.hs
@@ -16,10 +16,10 @@ import           Data.Monoid                 ((<>))
 import           Network                     hiding (accept, connectTo)
 
 main =
-  startRicochet (PortNumber 9878) Nothing (PortNumber 9051) [] (PortNumber 9050) [(1, handler)]
-    (\addr -> do
-      liftIO . print $ addr
-      void awaitConnection)
+  startRicochet (PortNumber 9878) Nothing (PortNumber 9051) [] (PortNumber 9050) [(1, handler)] $ do
+    addr <- use hiddenDomain
+    liftIO . print $ addr
+    void awaitConnection
 
 handler con =
   forever $ do

--- a/src/Network/Ricochet/Monad.hs
+++ b/src/Network/Ricochet/Monad.hs
@@ -13,11 +13,11 @@
 module Network.Ricochet.Monad
   ( Ricochet (..)
   , RicochetState (..)
-  , serverSocket, connections
-  , peekPacket, nextPacket
-  , socksPort, versions
-  , sendPacket, sendByteString
-  , closeConnection
+  , serverSocket, hiddenDomain
+  , connections, peekPacket
+  , nextPacket, socksPort
+  , versions, sendPacket
+  , sendByteString, closeConnection
   ) where
 
 import           Network.Ricochet.Protocol.Lowest
@@ -49,6 +49,7 @@ newtype Ricochet a = Ricochet { runRicochet :: StateT RicochetState IO a }
 -- | RicochetState is the state necessary for Ricochet
 data RicochetState = MkRicochetState
   { _serverSocket :: Socket                                -- ^ The socket listening for new peers
+  , _hiddenDomain :: ByteString                            -- ^ The domain of our hidden service
   , _connections  :: [Connection]                          -- ^ A list of the current open connections
   , _contactList  :: [Contact]                             -- ^ A list of known contacts
   , _socksPort    :: PortID                                -- ^ The port of the local Tor SOCKS proxy

--- a/src/Network/Ricochet/Types.hs
+++ b/src/Network/Ricochet/Types.hs
@@ -6,8 +6,8 @@
 lenses used throughout the package.
 -}
 
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TemplateHaskell            #-}
 module Network.Ricochet.Types where
 
 import           Control.Lens                     (makeLenses, makePrisms)
@@ -26,7 +26,7 @@ data Packet = MkPacket
   { _pSize       :: Word16     -- ^ The size of the whole packet
   , _pChannelID  :: Word16     -- ^ The channel the packet should be sent on
   , _pPacketData :: ByteString -- ^ The actual packet payload
-  } deriving (Show)
+  } deriving (Eq, Show)
 
 -- | Creates a packet with appropriate size from a Channel and a ByteString
 makePacket :: Word16     -- ^ ID of the channel the packet should be sent on
@@ -35,7 +35,8 @@ makePacket :: Word16     -- ^ ID of the channel the packet should be sent on
 makePacket chan bs = MkPacket (4 + fromIntegral (B.length bs)) chan bs
 
 -- | The role of a peer in a Connection
-data ConnectionRole = Client | Server deriving (Eq, Show)
+data ConnectionRole = Client | Server
+  deriving (Eq, Show)
 
 -- | Representation of a connection between two ricochet peers
 --   it consists of:
@@ -49,15 +50,15 @@ data Connection = MkConnection
   , _cConnectionRole :: ConnectionRole -- ^ The connection role of this side of the connection
   }
 
+-- | Equality is defined by equality of the socket
+instance Eq Connection where
+  a == b = _cHandle a == _cHandle b
+
 -- | Creates an initial 'Connection' from a Handle
 makeConnection :: Handle -> ConnectionRole -> Connection
 makeConnection handle role = -- Start out with only a Control Channel
   let channels = [MkChannel 0 $ MkChannelType "im.ricochet.control-channel"]
   in  MkConnection handle channels B.empty role
-
--- | Equality is defined by equality of the socket
-instance Eq Connection where
-  a == b = _cHandle a == _cHandle b
 
 -- | Low level representation of a ricochet channel
 data Channel = MkChannel
@@ -65,21 +66,27 @@ data Channel = MkChannel
   , _cChannelType :: ChannelType -- ^ The type of the channel
   }
 
+-- | Equality is defined by equality of the channel ID
+instance Eq Channel where
+  a == b = _cChannelID a == _cChannelID b
+
 -- | The type of a channel is preliminarily represented by a ByteString for extensibility
 data ChannelType = MkChannelType Text
+  deriving (Eq, Ord)
 
 -- | A contact, defined by his ID (Tor hidden service address without the .onion and the 'ricochet:' prefix) and his display name
 data Contact = MkContact
   { _cName       :: String          -- ^ The name assigned to the contact
   , _cRicochetID :: String          -- ^ The ricochet ID of a contact is their hidden service address without the ".onion"
   , _cApproval   :: ContactApproval -- ^ To what extent this contact is approved on both sides
-  }
+  } deriving (Eq)
 
 -- | The contact request stage of a contact
 data ContactApproval = KnownContact
                      | BlockedContact
                      | WeRequestedContact
                      | TheyRequestedContact
+                     deriving (Eq)
 
 -- | ParserResult holds the result of a parser in a way
 --   that is nice to handle within our library.

--- a/src/Network/Ricochet/Types.hs
+++ b/src/Network/Ricochet/Types.hs
@@ -68,11 +68,18 @@ data Channel = MkChannel
 -- | The type of a channel is preliminarily represented by a ByteString for extensibility
 data ChannelType = MkChannelType Text
 
--- | A contact, defined by his ID (TOR hidden service address without the .onion and the 'ricochet:' prefix) and his display name
+-- | A contact, defined by his ID (Tor hidden service address without the .onion and the 'ricochet:' prefix) and his display name
 data Contact = MkContact
-  { _cName       :: String -- ^ The name assigned to the contact
-  , _cRicochetID :: String -- ^ The ricochet ID of a contact is their hidden service address without the ".onion"
+  { _cName       :: String          -- ^ The name assigned to the contact
+  , _cRicochetID :: String          -- ^ The ricochet ID of a contact is their hidden service address without the ".onion"
+  , _cApproval   :: ContactApproval -- ^ To what extent this contact is approved on both sides
   }
+
+-- | The contact request stage of a contact
+data ContactApproval = KnownContact
+                     | BlockedContact
+                     | WeRequestedContact
+                     | TheyRequestedContact
 
 -- | ParserResult holds the result of a parser in a way
 --   that is nice to handle within our library.
@@ -84,4 +91,5 @@ makeLenses ''Packet
 makeLenses ''Connection
 makeLenses ''Channel
 makeLenses ''Contact
+makeLenses ''ContactApproval
 makePrisms ''ParserResult


### PR DESCRIPTION
This PR moves the Monad types from `Monad.hs` to `Types.hs` in order to prevent
dependency loops, and to have all the types in Types.  The description in
`Monad.hs` is consequently changed to “Functions for the Ricochet Monad.”

In addition, I added hooks, which allow us to subscribe functions to channels,
contact approval stages, and some Eq instances.

**EDIT:** Most of this is incorrect by now, see below.
