### PR TITLE
Add Network.Ricochet.Channel

### DIFF
--- a/haskell-ricochet.cabal
+++ b/haskell-ricochet.cabal
@@ -29,6 +29,7 @@ library
                      , Network.Ricochet.Types
                      , Network.Ricochet.Util
                      , Network.Ricochet.Version
+                     , Network.Ricochet.Channel
   other-modules:       Network.Ricochet.Crypto.RSA
                      , Network.Ricochet.Protocol.Data.AuthHiddenService
                      , Network.Ricochet.Protocol.Data.AuthHiddenService.Packet

--- a/src/Network/Ricochet/Channel.hs
+++ b/src/Network/Ricochet/Channel.hs
@@ -1,0 +1,63 @@
+{-|
+  Module:   Network.Ricochet.Channel
+  Description: Our custom spin on 'Channel's usually used in concurrent
+               programming
+
+"Network.Ricochet.Channel" implements our custom Channel type, which is the
+base of most of the higher-level API.
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+module Network.Ricochet.Channel
+  ( Channel
+  , newChannel
+  , dupChannel
+  , readChannel
+  , writeChannel
+  , transform
+  , mergeChannel
+  ) where
+
+import Control.Concurrent.Chan
+import Control.Monad (liftM, (>=>))
+import Control.Applicative (Alternative(..))
+
+-- | A 'Channel' of the source type s, transformed to yield values of type a
+data Channel s a = MkChannel (Chan s) (s -> Maybe a)
+
+-- | Create a new, empty 'Channel'
+newChannel :: IO (Channel s s)
+newChannel = flip MkChannel Just <$> newChan
+
+-- | Duplicate a 'Channel'. Everything written on either on can be read on both
+--   of them from now on.
+dupChannel :: Channel s a -> IO (Channel s a)
+dupChannel (MkChannel chan f) = flip MkChannel f <$> dupChan chan
+
+-- | Read the next value from a 'Channel'
+readChannel :: Channel s a -> IO a
+readChannel c@(MkChannel chan f) = f <$> readChan chan >>= \case
+                        Just v  -> return v
+                        Nothing -> readChannel c
+
+-- | Write a value to a 'Channel'
+writeChannel :: Channel s a -> s -> IO ()
+writeChannel (MkChannel chan _) = writeChan chan
+
+-- | Transform a 'Channel' into one yielding another type. This function can
+--   also be used to filter over 'Channel's.
+transform :: (a -> Maybe b) -> Channel s a -> Channel s b
+transform f (MkChannel chan g) = MkChannel chan (g >=> f)
+
+instance Functor (Channel s) where
+  fmap f = transform (Just . f)
+
+-- | Merge two 'Channel's with the same origin into one.
+--
+--   ATTENTION: Don't merge channels with different sources.
+mergeChannel :: Channel s a -> Channel s b -> Channel s (Either a b)
+mergeChannel (MkChannel chan f) (MkChannel chan' g)
+  | chan /= chan' = error "Trying to merge two Channels with different sources"
+  | otherwise     = MkChannel chan h
+  where h s = Left <$> f s <|> Right <$> g s

--- a/src/Network/Ricochet/Channel.hs
+++ b/src/Network/Ricochet/Channel.hs
@@ -8,6 +8,8 @@ base of most of the higher-level API.
 -}
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Network.Ricochet.Channel
   ( Channel
@@ -20,44 +22,54 @@ module Network.Ricochet.Channel
   ) where
 
 import Control.Concurrent.Chan
+import Control.Lens hiding (transform)
 import Control.Monad (liftM, (>=>))
 import Control.Applicative (Alternative(..))
 
 -- | A 'Channel' of the source type s, transformed to yield values of type a
-data Channel s a = MkChannel (Chan s) (s -> Maybe a)
+data Channel s a = MkChannel (Chan s) (APrism' s a)
 
 -- | Create a new, empty 'Channel'
 newChannel :: IO (Channel s s)
-newChannel = flip MkChannel Just <$> newChan
+newChannel = flip MkChannel (prism' id Just) <$> newChan
 
 -- | Duplicate a 'Channel'. Everything written on either on can be read on both
 --   of them from now on.
 dupChannel :: Channel s a -> IO (Channel s a)
-dupChannel (MkChannel chan f) = flip MkChannel f <$> dupChan chan
+dupChannel (MkChannel chan p) = flip MkChannel p <$> dupChan chan
 
 -- | Read the next value from a 'Channel'
 readChannel :: Channel s a -> IO a
-readChannel c@(MkChannel chan f) = f <$> readChan chan >>= \case
+readChannel c@(MkChannel chan p) = (^? clonePrism p) <$> readChan chan >>= \case
                         Just v  -> return v
                         Nothing -> readChannel c
 
 -- | Write a value to a 'Channel'
-writeChannel :: Channel s a -> s -> IO ()
-writeChannel (MkChannel chan _) = writeChan chan
+writeChannel :: Channel s a -> a -> IO ()
+writeChannel (MkChannel chan p) = writeChan chan . (^. (re . clonePrism $ p))
 
 -- | Transform a 'Channel' into one yielding another type. This function can
 --   also be used to filter over 'Channel's.
-transform :: (a -> Maybe b) -> Channel s a -> Channel s b
-transform f (MkChannel chan g) = MkChannel chan (g >=> f)
-
-instance Functor (Channel s) where
-  fmap f = transform (Just . f)
+transform :: APrism' a b -> Channel s a -> Channel s b
+transform q (MkChannel chan p) = MkChannel chan (clonePrism p.clonePrism q)
 
 -- | Merge two 'Channel's with the same origin into one.
 --
 --   ATTENTION: Don't merge channels with different sources.
 mergeChannel :: Channel s a -> Channel s b -> Channel s (Either a b)
-mergeChannel (MkChannel chan f) (MkChannel chan' g)
+mergeChannel (MkChannel chan p) (MkChannel chan' q)
   | chan /= chan' = error "Trying to merge two Channels with different sources"
-  | otherwise     = MkChannel chan h
-  where h s = Left <$> f s <|> Right <$> g s
+  | otherwise     = MkChannel chan r
+  where r = mergePrisms p q
+
+-- | Merges two 'Prism's the way we need it for 'mergeChannel'
+mergePrisms :: APrism' s a -> APrism' s b -> APrism' s (Either a b)
+mergePrisms p q = withPrism q . withPrism p $ f
+  where f pbt psta qbt qsta = prism rbt rsta
+          where rbt (Left  a) = pbt a
+                rbt (Right b) = qbt b
+                rsta s = case psta s of
+                         Right a -> Right . Left $ a
+                         Left s' -> case qsta s' of
+                           Right b  -> Right . Right $ b
+                           Left s'' -> Left s''

--- a/src/Network/Ricochet/Channel.hs
+++ b/src/Network/Ricochet/Channel.hs
@@ -29,9 +29,17 @@ import Control.Applicative (Alternative(..))
 -- | A 'Channel' of the source type s, transformed to yield values of type a
 data Channel s a = MkChannel (Chan s) (APrism' s a)
 
+-- | Helper function for creating source channels
+mkSource :: Chan s -> Channel s s
+mkSource = flip MkChannel (prism' id Just)
+
 -- | Create a new, empty 'Channel'
 newChannel :: IO (Channel s s)
-newChannel = flip MkChannel (prism' id Just) <$> newChan
+newChannel = mkSource <$> newChan
+
+-- | Duplicate a 'Channel', yielding a 'Channel' transporting the source type.
+dupSource :: Channel s a -> IO (Channel s s)
+dupSource (MkChannel c _) = mkSource <$> dupChan c
 
 -- | Duplicate a 'Channel'. Everything written on either on can be read on both
 --   of them from now on.


### PR DESCRIPTION
This PR implements the `Channel` type as discussed in the proposal.
There are two possible modifications I can offer for this:
- Making the transformation a `Prism' s a` instead of `s -> Maybe a` would allow us to send `a`s using `writeChannel`
- By writing our own low-level `Channel` type instead of using `Chan`, we could modify `mergeChannel` to allow the merging of arbitrary channels of the same type instead of only the ones with the same origin. This would work similarily to `dupChannel`.
